### PR TITLE
Fix BigImageView does not render in Android Studio layout editor

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -133,7 +133,11 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
             addView(mImageView);
         }
 
-        mImageLoader = BigImageViewer.imageLoader();
+        if (isInEditMode()) {
+            mImageLoader = null;
+        } else {
+            mImageLoader = BigImageViewer.imageLoader();
+        }
         mInternalCallback = ThreadedCallbacks.create(ImageLoader.Callback.class, this);
 
         mTempImages = new ArrayList<>();


### PR DESCRIPTION
BigImageView would cause "Rendering Problems" in Android Studio
if one used the visual ("Design") editor.

This is an alternative to PR #55