### PR TITLE
Do not pass XML attributes to default SSIV

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -128,7 +128,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
         array.recycle();
 
         if (mCustomSsivId == 0) {
-            mImageView = new SubsamplingScaleImageView(context, attrs);
+            mImageView = new SubsamplingScaleImageView(context);
             addView(mImageView);
         }
 


### PR DESCRIPTION
It does not make sense to pass `attrs` to SSIV, since the SSIV attrs are not allowed in XML on the BigImageView element (e.g. `app:assetName="..."` fails during gradle `assemble` task saying "No resource identifier found for attribute 'assetName'")

More importantly, it can result in nonsensical attrs passed to SSIV, resulting in a crash. Not sure why exactly this bug happens, maybe an incompatibility with another library, but it is resolved by not passing the `attrs` to the programmatically constructed SSIV.

Can define attributes using a custom SSIV instead.