### PR TITLE
Cancel image loader onDetachedFromWindow

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/loader/ImageLoader.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/loader/ImageLoader.java
@@ -36,13 +36,13 @@ import java.io.File;
 
 public interface ImageLoader {
 
-    void loadImage(BigImageView parent, Uri uri, Callback callback);
+    void loadImage(int requestId, Uri uri, Callback callback);
 
     View showThumbnail(BigImageView parent, Uri thumbnail, int scaleType);
 
     void prefetch(Uri uri);
 
-    void cancel(BigImageView parent);
+    void cancel(int requestId);
 
     @UiThread
     interface Callback {

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/loader/ImageLoader.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/loader/ImageLoader.java
@@ -36,11 +36,13 @@ import java.io.File;
 
 public interface ImageLoader {
 
-    void loadImage(Uri uri, Callback callback);
+    void loadImage(BigImageView parent, Uri uri, Callback callback);
 
     View showThumbnail(BigImageView parent, Uri thumbnail, int scaleType);
 
     void prefetch(Uri uri);
+
+    void cancel(BigImageView parent);
 
     @UiThread
     interface Callback {

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -297,6 +297,8 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
+        mImageLoader.cancel(this);
+
         for (int i = 0, size = mTempImages.size(); i < size; i++) {
             mTempImages.get(i).delete();
         }
@@ -310,7 +312,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
     public void showImage(final Uri thumbnail, final Uri uri) {
         mThumbnail = thumbnail;
         mUri = uri;
-        mImageLoader.loadImage(uri, mInternalCallback);
+        mImageLoader.loadImage(this, uri, mInternalCallback);
 
         if (mFailureImageView != null) {
             mFailureImageView.setVisibility(GONE);

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -297,7 +297,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        mImageLoader.cancel(this);
+        mImageLoader.cancel(hashCode());
 
         for (int i = 0, size = mTempImages.size(); i < size; i++) {
             mTempImages.get(i).delete();
@@ -312,7 +312,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
     public void showImage(final Uri thumbnail, final Uri uri) {
         mThumbnail = thumbnail;
         mUri = uri;
-        mImageLoader.loadImage(this, uri, mInternalCallback);
+        mImageLoader.loadImage(hashCode(), uri, mInternalCallback);
 
         if (mFailureImageView != null) {
             mFailureImageView.setVisibility(GONE);

--- a/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
+++ b/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
@@ -79,7 +79,7 @@ public final class FrescoImageLoader implements ImageLoader {
     }
 
     @Override
-    public void loadImage(Uri uri, final Callback callback) {
+    public void loadImage(BigImageView parent, Uri uri, final Callback callback) {
         ImageRequest request = ImageRequest.fromUri(uri);
 
         File localCache = getCacheFile(request);
@@ -147,6 +147,11 @@ public final class FrescoImageLoader implements ImageLoader {
         ImagePipeline pipeline = Fresco.getImagePipeline();
         pipeline.prefetchToDiskCache(ImageRequest.fromUri(uri),
                 false); // we don't need context, but avoid null
+    }
+
+    @Override
+    public void cancel(BigImageView parent) {
+
     }
 
     private File getCacheFile(final ImageRequest request) {

--- a/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
+++ b/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
@@ -59,7 +59,7 @@ public final class FrescoImageLoader implements ImageLoader {
     private final Context mAppContext;
     private final DefaultExecutorSupplier mExecutorSupplier;
 
-    private final ConcurrentHashMap<Integer, DataSource> mViewSourceMap
+    private final ConcurrentHashMap<Integer, DataSource> mRequestSourceMap
             = new ConcurrentHashMap<>();
 
     private FrescoImageLoader(Context appContext) {
@@ -83,7 +83,7 @@ public final class FrescoImageLoader implements ImageLoader {
     }
 
     @Override
-    public void loadImage(BigImageView parent, Uri uri, final Callback callback) {
+    public void loadImage(int requestId, Uri uri, final Callback callback) {
         ImageRequest request = ImageRequest.fromUri(uri);
 
         File localCache = getCacheFile(request);
@@ -117,17 +117,17 @@ public final class FrescoImageLoader implements ImageLoader {
                 }
             }, mExecutorSupplier.forBackgroundTasks());
 
-            closeSource(parent);
-            saveSource(parent, source);
+            closeSource(requestId);
+            saveSource(requestId, source);
         }
     }
 
-    private void saveSource(BigImageView parent, DataSource target) {
-        mViewSourceMap.put(parent.hashCode(), target);
+    private void saveSource(int requestId, DataSource target) {
+        mRequestSourceMap.put(requestId, target);
     }
 
-    private void closeSource(BigImageView parent) {
-        DataSource source = mViewSourceMap.remove(parent.hashCode());
+    private void closeSource(int requestId) {
+        DataSource source = mRequestSourceMap.remove(requestId);
         if (source != null) {
             source.close();
         }
@@ -168,8 +168,8 @@ public final class FrescoImageLoader implements ImageLoader {
     }
 
     @Override
-    public void cancel(BigImageView parent) {
-        closeSource(parent);
+    public void cancel(int requestId) {
+        closeSource(requestId);
     }
 
     private File getCacheFile(final ImageRequest request) {

--- a/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
+++ b/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
@@ -59,7 +59,7 @@ public final class FrescoImageLoader implements ImageLoader {
     private final Context mAppContext;
     private final DefaultExecutorSupplier mExecutorSupplier;
 
-    private final ConcurrentHashMap<BigImageView, DataSource> mViewSourceMap
+    private final ConcurrentHashMap<Integer, DataSource> mViewSourceMap
             = new ConcurrentHashMap<>();
 
     private FrescoImageLoader(Context appContext) {
@@ -123,11 +123,11 @@ public final class FrescoImageLoader implements ImageLoader {
     }
 
     private void saveSource(BigImageView parent, DataSource target) {
-        mViewSourceMap.put(parent, target);
+        mViewSourceMap.put(parent.hashCode(), target);
     }
 
     private void closeSource(BigImageView parent) {
-        DataSource source = mViewSourceMap.remove(parent);
+        DataSource source = mViewSourceMap.remove(parent.hashCode());
         if (source != null) {
             source.close();
         }

--- a/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
+++ b/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
@@ -72,6 +72,7 @@ public final class GlideImageLoader implements ImageLoader {
             @Override
             public void onResourceReady(File resource,
                                         Transition<? super File> transition) {
+                super.onResourceReady(resource, transition);
                 // we don't need delete this image file, so it behaves live cache hit
                 callback.onCacheHit(resource);
                 callback.onSuccess(resource);
@@ -79,6 +80,7 @@ public final class GlideImageLoader implements ImageLoader {
 
             @Override
             public void onLoadFailed(final Drawable errorDrawable) {
+                super.onLoadFailed(errorDrawable);
                 callback.onFail(new GlideLoaderException(errorDrawable));
             }
 

--- a/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
+++ b/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
@@ -50,7 +50,7 @@ import okhttp3.OkHttpClient;
 public final class GlideImageLoader implements ImageLoader {
     private final RequestManager mRequestManager;
 
-    private final ConcurrentHashMap<Integer, ImageDownloadTarget> mViewTargetMap
+    private final ConcurrentHashMap<Integer, ImageDownloadTarget> mRequestTargetMap
             = new ConcurrentHashMap<>();
 
     private GlideImageLoader(Context context, OkHttpClient okHttpClient) {
@@ -67,7 +67,7 @@ public final class GlideImageLoader implements ImageLoader {
     }
 
     @Override
-    public void loadImage(final BigImageView parent, final Uri uri, final Callback callback) {
+    public void loadImage(final int requestId, final Uri uri, final Callback callback) {
         ImageDownloadTarget target = new ImageDownloadTarget(uri.toString()) {
             @Override
             public void onResourceReady(File resource,
@@ -99,8 +99,8 @@ public final class GlideImageLoader implements ImageLoader {
                 callback.onFinish();
             }
         };
-        clearTarget(parent);
-        saveTarget(parent, target);
+        clearTarget(requestId);
+        saveTarget(requestId, target);
 
         mRequestManager
                 .downloadOnly()
@@ -108,12 +108,12 @@ public final class GlideImageLoader implements ImageLoader {
                 .into(target);
     }
 
-    private void saveTarget(BigImageView parent, ImageDownloadTarget target) {
-        mViewTargetMap.put(parent.hashCode(), target);
+    private void saveTarget(int requestId, ImageDownloadTarget target) {
+        mRequestTargetMap.put(requestId, target);
     }
 
-    private void clearTarget(BigImageView parent) {
-        ImageDownloadTarget target = mViewTargetMap.remove(parent.hashCode());
+    private void clearTarget(int requestId) {
+        ImageDownloadTarget target = mRequestTargetMap.remove(requestId);
         if (target != null) {
             mRequestManager.clear(target);
         }
@@ -157,7 +157,7 @@ public final class GlideImageLoader implements ImageLoader {
     }
 
     @Override
-    public void cancel(BigImageView parent) {
-        clearTarget(parent);
+    public void cancel(int requestId) {
+        clearTarget(requestId);
     }
 }

--- a/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
+++ b/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
@@ -50,7 +50,7 @@ import okhttp3.OkHttpClient;
 public final class GlideImageLoader implements ImageLoader {
     private final RequestManager mRequestManager;
 
-    private final ConcurrentHashMap<BigImageView, ImageDownloadTarget> mViewTargetMap
+    private final ConcurrentHashMap<Integer, ImageDownloadTarget> mViewTargetMap
             = new ConcurrentHashMap<>();
 
     private GlideImageLoader(Context context, OkHttpClient okHttpClient) {
@@ -109,11 +109,11 @@ public final class GlideImageLoader implements ImageLoader {
     }
 
     private void saveTarget(BigImageView parent, ImageDownloadTarget target) {
-        mViewTargetMap.put(parent, target);
+        mViewTargetMap.put(parent.hashCode(), target);
     }
 
     private void clearTarget(BigImageView parent) {
-        ImageDownloadTarget target = mViewTargetMap.remove(parent);
+        ImageDownloadTarget target = mViewTargetMap.remove(parent.hashCode());
         if (target != null) {
             mRequestManager.clear(target);
         }

--- a/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/ImageDownloadTarget.java
+++ b/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/ImageDownloadTarget.java
@@ -26,6 +26,8 @@ package com.github.piasy.biv.loader.glide;
 
 import android.graphics.drawable.Drawable;
 import com.bumptech.glide.request.target.SimpleTarget;
+import com.bumptech.glide.request.transition.Transition;
+
 import java.io.File;
 
 /**
@@ -38,6 +40,11 @@ public abstract class ImageDownloadTarget extends SimpleTarget<File> implements
 
     protected ImageDownloadTarget(String url) {
         mUrl = url;
+    }
+
+    @Override
+    public void onResourceReady(File resource, Transition<? super File> transition) {
+        GlideProgressSupport.forget(mUrl);
     }
 
     @Override


### PR DESCRIPTION
I was able to reproduce the memory leak on BigImageViewer 1.4.4, both in LeakCanary and by looking at the heap with Android Device Monitor, using the sample app's Glide loader, loading a large image and exiting the activity repeatedly.

After this patch I can no longer reproduce the leak. The heap is properly cleared when forcing garbage collection.

fixes #36 

fixes #43 
