### PR TITLE
fix: memory leak when use it in RecyclerView https://github.com/Piasy…

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/loader/ImageLoader.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/loader/ImageLoader.java
@@ -40,6 +40,8 @@ public interface ImageLoader {
 
     void cancel(int requestId);
 
+    void cancelAll();
+
     @UiThread
     interface Callback {
         void onCacheHit(int imageType, File image);

--- a/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
+++ b/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
@@ -134,6 +134,13 @@ public final class FrescoImageLoader implements ImageLoader {
         closeSource(requestId);
     }
 
+    @Override
+    public void cancelAll() {
+        for (Integer key : mRequestSourceMap.keySet()) {
+            cancel(key);
+        }
+    }
+
     private void saveSource(int requestId, DataSource target) {
         mRequestSourceMap.put(requestId, target);
     }

--- a/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
+++ b/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
@@ -120,6 +120,13 @@ public class GlideImageLoader implements ImageLoader {
         clearTarget(requestId);
     }
 
+    @Override
+    public void cancelAll() {
+        for (Integer key : mRequestTargetMap.keySet()) {
+            cancel(key);
+        }
+    }
+
     private void saveTarget(int requestId, ImageDownloadTarget target) {
         mRequestTargetMap.put(requestId, target);
     }


### PR DESCRIPTION
…/BigImageViewer/issues/124

Call `BigImageViewer.imageLoader().cancelAll();` in target activity/fragment `onDestory` cycle