### PR TITLE
Change method name 'with' to 'createImageLoader'

### DIFF
--- a/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
+++ b/GlideImageLoader/src/main/java/com/github/piasy/biv/loader/glide/GlideImageLoader.java
@@ -57,10 +57,10 @@ public class GlideImageLoader implements ImageLoader {
     }
 
     public static GlideImageLoader with(Context context) {
-        return with(context, null);
+        return createImageLoader(context, null);
     }
 
-    public static GlideImageLoader with(Context context, OkHttpClient okHttpClient) {
+    public static GlideImageLoader createImageLoader(Context context, OkHttpClient okHttpClient) {
         return new GlideImageLoader(context, okHttpClient);
     }
 


### PR DESCRIPTION
This class is used to represent GlideImageLoader.  This method named 'with' is to create an image loader. Thus, the method name 'createImageLoader' is more intuitive than 'with'.