### PR TITLE
updated deps and minor fixes, pre animation works

### DIFF
--- a/BigImageViewer/build.gradle
+++ b/BigImageViewer/build.gradle
@@ -45,5 +45,5 @@ android {
 }
 
 dependencies {
-    implementation "com.davemorrissey.labs:subsampling-scale-image-view:$rootProject.ext.ssivVersion"
+    api "com.davemorrissey.labs:subsampling-scale-image-view:$rootProject.ext.ssivVersion"
 }

--- a/BigImageViewer/build.gradle
+++ b/BigImageViewer/build.gradle
@@ -45,5 +45,5 @@ android {
 }
 
 dependencies {
-    api "com.davemorrissey.labs:subsampling-scale-image-view:$rootProject.ext.ssivVersion"
+    implementation "com.davemorrissey.labs:subsampling-scale-image-view:$rootProject.ext.ssivVersion"
 }

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/metadata/ImageInfoExtractor.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/metadata/ImageInfoExtractor.java
@@ -71,6 +71,7 @@ public final class ImageInfoExtractor {
 
             inputStream.close();
         } catch (IOException e) {
+            e.printStackTrace();
         }
 
         return type;

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -106,7 +106,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
 
     private OnClickListener mOnClickListener;
     private OnLongClickListener mOnLongClickListener;
-    private OnClickListener mFailureImageClickListener = new OnClickListener() {
+    private final OnClickListener mFailureImageClickListener = new OnClickListener() {
         @Override
         public void onClick(final View v) {
             // Retry loading when failure image is clicked

--- a/FrescoImageLoader/build.gradle
+++ b/FrescoImageLoader/build.gradle
@@ -47,7 +47,8 @@ android {
 }
 
 dependencies {
-    api project(':BigImageViewer')
+    implementation project(':BigImageViewer')
 
-    api "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
+    implementation "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
+    implementation "androidx.annotation:annotation:$rootProject.ext.annotationVersion"
 }

--- a/FrescoImageLoader/build.gradle
+++ b/FrescoImageLoader/build.gradle
@@ -49,6 +49,6 @@ android {
 dependencies {
     implementation project(':BigImageViewer')
 
-    implementation "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
+    api "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
     implementation "androidx.annotation:annotation:$rootProject.ext.annotationVersion"
 }

--- a/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
+++ b/FrescoImageLoader/src/main/java/com/github/piasy/biv/loader/fresco/FrescoImageLoader.java
@@ -24,6 +24,7 @@
 
 package com.github.piasy.biv.loader.fresco;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
 import com.facebook.binaryresource.FileBinaryResource;
@@ -77,6 +78,7 @@ public final class FrescoImageLoader implements ImageLoader {
         return new FrescoImageLoader(appContext);
     }
 
+    @SuppressLint("WrongThread")
     @Override
     public void loadImage(int requestId, Uri uri, final Callback callback) {
         ImageRequest request = ImageRequest.fromUri(uri);

--- a/FrescoImageViewFactory/build.gradle
+++ b/FrescoImageViewFactory/build.gradle
@@ -49,8 +49,8 @@ android {
 dependencies {
     implementation project(':BigImageViewer')
 
-    implementation "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
-    implementation "com.facebook.fresco:animated-gif:$rootProject.ext.frescoVersion"
-    implementation "com.facebook.fresco:animated-webp:$rootProject.ext.frescoVersion"
-    implementation "com.facebook.fresco:webpsupport:$rootProject.ext.frescoVersion"
+    api "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
+    api "com.facebook.fresco:animated-gif:$rootProject.ext.frescoVersion"
+    api "com.facebook.fresco:animated-webp:$rootProject.ext.frescoVersion"
+    api "com.facebook.fresco:webpsupport:$rootProject.ext.frescoVersion"
 }

--- a/FrescoImageViewFactory/build.gradle
+++ b/FrescoImageViewFactory/build.gradle
@@ -47,10 +47,10 @@ android {
 }
 
 dependencies {
-    api project(':BigImageViewer')
+    implementation project(':BigImageViewer')
 
-    api "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
-    api "com.facebook.fresco:animated-gif:$rootProject.ext.frescoVersion"
-    api "com.facebook.fresco:animated-webp:$rootProject.ext.frescoVersion"
-    api "com.facebook.fresco:webpsupport:$rootProject.ext.frescoVersion"
+    implementation "com.facebook.fresco:fresco:$rootProject.ext.frescoVersion"
+    implementation "com.facebook.fresco:animated-gif:$rootProject.ext.frescoVersion"
+    implementation "com.facebook.fresco:animated-webp:$rootProject.ext.frescoVersion"
+    implementation "com.facebook.fresco:webpsupport:$rootProject.ext.frescoVersion"
 }

--- a/GlideImageLoader/build.gradle
+++ b/GlideImageLoader/build.gradle
@@ -49,8 +49,8 @@ android {
 dependencies {
     implementation project(':BigImageViewer')
 
-    implementation "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
-    implementation "com.github.bumptech.glide:okhttp3-integration:$rootProject.ext.glideVersion"
+    api "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
+    api "com.github.bumptech.glide:okhttp3-integration:$rootProject.ext.glideVersion"
     annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.ext.glideVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
 

--- a/GlideImageLoader/build.gradle
+++ b/GlideImageLoader/build.gradle
@@ -47,9 +47,12 @@ android {
 }
 
 dependencies {
-    api project(':BigImageViewer')
+    implementation project(':BigImageViewer')
 
-    api "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
-    api "com.github.bumptech.glide:okhttp3-integration:$rootProject.ext.glideVersion"
-    api 'com.squareup.okhttp3:okhttp:3.11.0'
+    implementation "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
+    implementation "com.github.bumptech.glide:okhttp3-integration:$rootProject.ext.glideVersion"
+    annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.ext.glideVersion"
+    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+
+    implementation "androidx.annotation:annotation:$rootProject.ext.annotationVersion"
 }

--- a/GlideImageViewFactory/build.gradle
+++ b/GlideImageViewFactory/build.gradle
@@ -47,8 +47,8 @@ android {
 }
 
 dependencies {
-    api project(':BigImageViewer')
+    implementation project(':BigImageViewer')
 
-    api "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
-    api 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'
+    implementation "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'
 }

--- a/GlideImageViewFactory/build.gradle
+++ b/GlideImageViewFactory/build.gradle
@@ -49,6 +49,6 @@ android {
 dependencies {
     implementation project(':BigImageViewer')
 
-    implementation "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
+    api "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'
 }

--- a/ProgressPieIndicator/build.gradle
+++ b/ProgressPieIndicator/build.gradle
@@ -47,5 +47,5 @@ android {
 dependencies {
     implementation project(':BigImageViewer')
 
-    implementation 'com.github.filippudak.progresspieview:library:1.0.4'
+    api 'com.github.filippudak.progresspieview:library:1.0.4'
 }

--- a/ProgressPieIndicator/build.gradle
+++ b/ProgressPieIndicator/build.gradle
@@ -45,7 +45,7 @@ android {
 }
 
 dependencies {
-    api project(':BigImageViewer')
+    implementation project(':BigImageViewer')
 
-    api('com.github.filippudak.progresspieview:library:1.0.4')
+    implementation 'com.github.filippudak.progresspieview:library:1.0.4'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ android {
     buildToolsVersion rootProject.ext.androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
+        minSdkVersion 15
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.releaseVersionCode
         versionName rootProject.ext.releaseVersionName
@@ -95,10 +95,4 @@ dependencies {
     implementation project(':FrescoImageViewFactory')
     implementation project(':GlideImageViewFactory')
     implementation project(':ProgressPieIndicator')
-
-    implementation "com.davemorrissey.labs:subsampling-scale-image-view:$rootProject.ext.ssivVersion"
-
-    implementation "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
-    implementation "com.github.bumptech.glide:okhttp3-integration:$rootProject.ext.glideVersion"
-    annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.ext.glideVersion"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ android {
     buildToolsVersion rootProject.ext.androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.releaseVersionCode
         versionName rootProject.ext.releaseVersionName
@@ -38,6 +38,7 @@ android {
         applicationId "com.github.piasy.biv.example"
 
         vectorDrawables.useSupportLibrary = true
+        multiDexEnabled true
     }
 
     signingConfigs {
@@ -71,27 +72,33 @@ android {
 }
 
 dependencies {
-    api "androidx.appcompat:appcompat:$rootProject.ext.androidXVersion"
-    api "androidx.recyclerview:recyclerview:$rootProject.ext.androidXVersion"
-    annotationProcessor "androidx.annotation:annotation:$rootProject.ext.androidXVersion"
-
-    implementation('com.afollestad.material-dialogs:core:0.9.6.0')
+    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "com.google.android.material:material:$materialVersion"
 
     implementation('com.tbruyelle.rxpermissions2:rxpermissions:0.9.5') {
         exclude module: 'rxjava'
     }
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    implementation 'com.github.akarnokd:rxjava2-interop:0.13.2'
-    implementation('com.github.piasy:RxQrCode:1.3.0')
-    implementation 'com.squareup.leakcanary:leakcanary-android:1.6.2'
+    implementation('com.github.akarnokd:rxjava2-interop:0.13.7') {
+        exclude module: 'rxjava'
+    }
+
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.13'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    implementation 'com.github.piasy:RxQrCode:1.3.0'
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-beta-3'
 
     implementation project(':BigImageViewer')
     implementation project(':FrescoImageLoader')
     implementation project(':GlideImageLoader')
     implementation project(':FrescoImageViewFactory')
     implementation project(':GlideImageViewFactory')
-    annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.ext.glideVersion"
-
     implementation project(':ProgressPieIndicator')
+
+    implementation "com.davemorrissey.labs:subsampling-scale-image-view:$rootProject.ext.ssivVersion"
+
+    implementation "com.github.bumptech.glide:glide:$rootProject.ext.glideVersion"
+    implementation "com.github.bumptech.glide:okhttp3-integration:$rootProject.ext.glideVersion"
+    annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.ext.glideVersion"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,13 +24,11 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
-        package="com.github.piasy.biv.example"
-        >
+        package="com.github.piasy.biv.example">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
-            android:name=".App"
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"

--- a/app/src/main/java/com/github/piasy/biv/example/App.java
+++ b/app/src/main/java/com/github/piasy/biv/example/App.java
@@ -30,7 +30,6 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.github.piasy.biv.utils.IOUtils;
-import com.squareup.leakcanary.LeakCanary;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -85,16 +84,5 @@ public class App extends Application {
             IOUtils.closeQuietly(input);
         }
         return line;
-    }
-
-    @Override
-    public void onCreate() {
-        super.onCreate();
-        if (LeakCanary.isInAnalyzerProcess(this)) {
-            // This process is dedicated to LeakCanary for heap analysis.
-            // You should not init your app in this process.
-            return;
-        }
-        LeakCanary.install(this);
     }
 }

--- a/app/src/main/java/com/github/piasy/biv/example/GlideLoaderActivity.java
+++ b/app/src/main/java/com/github/piasy/biv/example/GlideLoaderActivity.java
@@ -51,7 +51,7 @@ public class GlideLoaderActivity extends AppCompatActivity {
                 bigImageView.setProgressIndicator(new ProgressPieIndicator());
                 bigImageView.showImage(
                         Uri.parse("http://img1.imgtn.bdimg.com/it/u=1520386803,778399414&fm=21&gp=0.jpg"),
-                        Uri.parse("http://youimg1.c-ctrip.com/target/tg/773/732/734/7ca19416b8cd423f8f6ef2d08366b7dc.jpg")
+                        Uri.parse("https://youimg1.c-ctrip.com/target/tg/773/732/734/7ca19416b8cd423f8f6ef2d08366b7dc.jpg")
                 );
             }
         });

--- a/app/src/main/java/com/github/piasy/biv/example/GlideLoaderActivity.java
+++ b/app/src/main/java/com/github/piasy/biv/example/GlideLoaderActivity.java
@@ -62,9 +62,9 @@ public class GlideLoaderActivity extends AppCompatActivity {
         super.onDestroy();
 
         long start = System.nanoTime();
-        App.fixLeakCanary696(getApplicationContext());
+        Utils.fixLeakCanary696(getApplicationContext());
         long end = System.nanoTime();
-        Log.w(App.TAG, "fixLeakCanary696: " + (end - start));
+        Log.w(Utils.TAG, "fixLeakCanary696: " + (end - start));
 
         BigImageViewer.imageLoader().cancelAll();
     }

--- a/app/src/main/java/com/github/piasy/biv/example/LongImageActivity.java
+++ b/app/src/main/java/com/github/piasy/biv/example/LongImageActivity.java
@@ -25,13 +25,16 @@
 package com.github.piasy.biv.example;
 
 import android.Manifest;
+import android.app.Dialog;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.view.View;
+import android.view.WindowManager;
+import android.widget.TextView;
 import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
-import com.afollestad.materialdialogs.MaterialDialog;
+
 import com.github.piasy.biv.BigImageViewer;
 import com.github.piasy.biv.indicator.progresspie.ProgressPieIndicator;
 import com.github.piasy.biv.loader.fresco.FrescoImageLoader;
@@ -52,6 +55,8 @@ public class LongImageActivity extends AppCompatActivity {
     private Disposable mPermissionRequest;
     private Disposable mQrCodeDecode;
 
+    private Dialog dialog;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -68,24 +73,36 @@ public class LongImageActivity extends AppCompatActivity {
             }
         });
 
+        dialog = new Dialog(this);
+        dialog.setTitle(R.string.long_click_actions);
+        dialog.setContentView(R.layout.dialog_long_image);
+
+        final WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
+        lp.copyFrom(dialog.getWindow().getAttributes());
+        lp.width = WindowManager.LayoutParams.MATCH_PARENT;
+        dialog.getWindow().setAttributes(lp);
+
+        final TextView textScan = dialog.findViewById(R.id.action_scan_qr);
+        final TextView textSave = dialog.findViewById(R.id.action_save_image);
+
+        textScan.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                decodeQrCode();
+            }
+        });
+
+        textSave.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                saveImage();
+            }
+        });
+
         mBigImageView.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                new MaterialDialog.Builder(LongImageActivity.this)
-                        .items(R.array.big_image_ops)
-                        .itemsCallback(new MaterialDialog.ListCallback() {
-                            @Override
-                            public void onSelection(MaterialDialog dialog, View itemView,
-                                    int position, CharSequence text) {
-                                if (TextUtils.equals(text, getString(R.string.save_image))) {
-                                    saveImage();
-                                } else if (TextUtils.equals(text,
-                                        getString(R.string.scan_qr_code))) {
-                                    decodeQrCode();
-                                }
-                            }
-                        })
-                        .show();
+                dialog.show();
                 return true;
             }
         });
@@ -112,8 +129,7 @@ public class LongImageActivity extends AppCompatActivity {
         findViewById(R.id.mBtnLoad).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mBigImageView.showImage(Uri.parse(
-                        "http://ww1.sinaimg.cn/mw690/005Fj2RDgw1f9mvl4pivvj30c82ougw3.jpg"));
+                mBigImageView.showImage(Uri.parse("https://ww1.sinaimg.cn/mw690/005Fj2RDgw1f9mvl4pivvj30c82ougw3.jpg"));
             }
         });
     }
@@ -124,6 +140,10 @@ public class LongImageActivity extends AppCompatActivity {
 
         disposePermissionRequest();
         disposeQrCodeDecode();
+
+        if (dialog.isShowing()) {
+            dialog.dismiss();
+        }
 
         BigImageViewer.imageLoader().cancelAll();
     }

--- a/app/src/main/java/com/github/piasy/biv/example/RecyclerViewActivity.java
+++ b/app/src/main/java/com/github/piasy/biv/example/RecyclerViewActivity.java
@@ -36,39 +36,39 @@ public class RecyclerViewActivity extends AppCompatActivity {
         final List<String> imageUrlsList = new ArrayList<>();
 
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/3/3f/Francisco_de_Goya_y_Lucientes_-_Los_fusilamientos_del_tres_de_mayo_-_1814.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/3/3f/Francisco_de_Goya_y_Lucientes_-_Los_fusilamientos_del_tres_de_mayo_-_1814.jpg");
         imageUrlsList.add(
-            "https://mathiasbynens.be/demo/animated-webp-supported.webp");
+                "https://mathiasbynens.be/demo/animated-webp-supported.webp");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/9/99/Las_Meninas_01.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/9/99/Las_Meninas_01.jpg");
         imageUrlsList.add(
                 "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/f/f1/El_caballero_de_la_mano_en_el_pecho.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/f/f1/El_caballero_de_la_mano_en_el_pecho.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/a/aa/SmallFullColourGIF.gif");
+                "https://upload.wikimedia.org/wikipedia/commons/a/aa/SmallFullColourGIF.gif");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/6/62/The_Garden_of_Earthly_Delights_by_Bosch_High_Resolution_2.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/6/62/The_Garden_of_Earthly_Delights_by_Bosch_High_Resolution_2.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/f/fb/La_Anunciaci%C3%B3n_%28Fra_Angelico-Prado%29.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/f/fb/La_Anunciaci%C3%B3n_%28Fra_Angelico-Prado%29.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Carlos_V_en_M%C3%BChlberg%2C_by_Titian%2C_from_Prado_in_Google_Earth.jpg/3000px-Carlos_V_en_M%C3%BChlberg%2C_by_Titian%2C_from_Prado_in_Google_Earth.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Carlos_V_en_M%C3%BChlberg%2C_by_Titian%2C_from_Prado_in_Google_Earth.jpg/3000px-Carlos_V_en_M%C3%BChlberg%2C_by_Titian%2C_from_Prado_in_Google_Earth.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/b/bb/Rembrandt_Harmensz._van_Rijn_014.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/b/bb/Rembrandt_Harmensz._van_Rijn_014.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/b/b2/Peter_Paul_Rubens_-_The_Three_Graces%2C_1635.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/b/b2/Peter_Paul_Rubens_-_The_Three_Graces%2C_1635.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/1/16/Raffael_048.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/1/16/Raffael_048.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/d/d4/Crucifixi%C3%B3n_Juan_de_Flandes.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/d/d4/Crucifixi%C3%B3n_Juan_de_Flandes.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/d/da/Albrecht_D%C3%BCrer_103.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/d/da/Albrecht_D%C3%BCrer_103.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/1/1a/Weyden_Deposition.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/1/1a/Weyden_Deposition.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/b/b6/El_sue%C3%B1o_de_Jacob%2C_por_Jos%C3%A9_de_Ribera.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/b/b6/El_sue%C3%B1o_de_Jacob%2C_por_Jos%C3%A9_de_Ribera.jpg");
         imageUrlsList.add(
-            "https://upload.wikimedia.org/wikipedia/commons/8/8b/Giovanni_Battista_Tiepolo_022.jpg");
+                "https://upload.wikimedia.org/wikipedia/commons/8/8b/Giovanni_Battista_Tiepolo_022.jpg");
 
         RecyclerView recycler = findViewById(R.id.recycler);
         recycler.setLayoutManager(

--- a/app/src/main/java/com/github/piasy/biv/example/Utils.java
+++ b/app/src/main/java/com/github/piasy/biv/example/Utils.java
@@ -1,48 +1,21 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2018 Piasy
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 package com.github.piasy.biv.example;
 
-import android.app.Application;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.Log;
 
 import com.github.piasy.biv.utils.IOUtils;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 
-/**
- * Created by Piasy{github.com/Piasy} on 22/04/2017.
- */
+public class Utils {
 
-public class App extends Application {
-    static final String TAG = "BIV-App";
+    public static final String TAG = "BIV-App";
 
-    static void fixLeakCanary696(Context context) {
+    public static void fixLeakCanary696(Context context) {
         if (!isEmui()) {
             Log.w(TAG, "not emui");
             return;
@@ -65,11 +38,11 @@ public class App extends Application {
         }
     }
 
-    static boolean isEmui() {
+    private static boolean isEmui() {
         return !TextUtils.isEmpty(getSystemProperty("ro.build.version.emui"));
     }
 
-    static String getSystemProperty(String propName) {
+    private static String getSystemProperty(String propName) {
         String line;
         BufferedReader input = null;
         try {

--- a/app/src/main/res/layout/dialog_long_image.xml
+++ b/app/src/main/res/layout/dialog_long_image.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/action_scan_qr"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/scan_qr_code"
+        android:layout_margin="16dp"
+        android:textStyle="bold"
+        android:textAlignment="center"
+        />
+
+    <TextView
+        android:id="@+id/action_save_image"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/save_image"
+        android:layout_margin="16dp"
+        android:textStyle="bold"
+        android:textAlignment="center"
+        />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">BIV</string>
 
+    <string name="long_click_actions">Actions:</string>
     <string name="scan_qr_code">recognize qr code</string>
     <string name="save_image">save to gallery</string>
     <string-array name="big_image_ops">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
 
     androidCompileSdkVersion = 29
     androidBuildToolsVersion = '29.0.2'
-    minSdkVersion = 15
+    minSdkVersion = 14
     targetSdkVersion = 29
 
     materialVersion = '1.1.0-beta01'

--- a/build.gradle
+++ b/build.gradle
@@ -33,13 +33,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
         // ./gradlew dependencyUpdates
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.25.0'
     }
 }
 
@@ -47,9 +47,8 @@ allprojects {
     repositories {
         jcenter()
         google()
-        maven {
-            url  "http://dl.bintray.com/piasy/maven"
-        }
+
+        maven { url  "http://dl.bintray.com/piasy/maven" }
     }
 }
 
@@ -78,13 +77,16 @@ ext {
     releaseVersionCode = 34
     releaseVersionName = '1.5.7'
 
-    androidCompileSdkVersion = 28
-    androidBuildToolsVersion = '28.0.3'
-    androidXVersion = '1.0.0'
-    minSdkVersion = 14
-    targetSdkVersion = 28
+    androidCompileSdkVersion = 29
+    androidBuildToolsVersion = '29.0.2'
+    minSdkVersion = 15
+    targetSdkVersion = 29
 
-    frescoVersion = '1.13.0'
-    glideVersion = '4.9.0'
+    materialVersion = '1.1.0-beta01'
+    annotationVersion = '1.1.0'
+
+    frescoVersion = '2.0.0'
+    glideVersion = '4.10.0'
+    okhttpVersion = '4.2.1'
     ssivVersion = '3.10.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,10 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+#enable R8
+android.enableR8=true
+android.enableD8.desugaring=true
+
+#enables AGP to use gradle workers
+android.enableGradleWorkers=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,7 +22,10 @@
  * SOFTWARE.
  */
 
-include ':app', ':BigImageViewer', 
-        ':FrescoImageLoader', ':GlideImageLoader',
-        ':FrescoImageViewFactory', ':GlideImageViewFactory',
-        ':ProgressPieIndicator'
+include(':app')
+include(':BigImageViewer')
+include(':FrescoImageLoader')
+include(':GlideImageLoader')
+include(':FrescoImageViewFactory')
+include(':GlideImageViewFactory')
+include(':ProgressPieIndicator')


### PR DESCRIPTION
I can no longer run away from #98,
I'm trying to prepare the work to make it better with shared animations.

But before that, I tried to fix some problems and update stuff in general, I created a PR, if you don't want to accept it, I'll just work on my fork.

What I did:

-updated to sdk 29
-updated deps
-updated gradle to 5.6.2
-updated gradle plugin 3.5.1
-update min sdk to 15, since 14 is less than 1% and not on the dashboard
-changed images urls to https when available to avoid error in newer versions of android / android studio
-don't use api on deps everywhere, this is not good practice, switched to implementation.
-removed material-dialogs, don't use a library only for a dialog in the sample app, switched to a standard dialog
-switched to material design components style for the sample app
-enabled multi dex for the sample app, cause the method limit is close.
-fixed minor errors when trivial

Suggestions:
-should we raise the min sdk to 19 or at least 17? some deps require newer versions of the ndk, and with restrictions next year (I think) it would be a good idea... I'm not making that big of a step on my own, what do you think?