### PR TITLE
shared animation works and test, fixed warnings and test app

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageCycleCallback.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageCycleCallback.java
@@ -1,0 +1,10 @@
+package com.github.piasy.biv.view;
+
+import androidx.annotation.UiThread;
+
+@UiThread
+public interface ImageCycleCallback {
+
+    void onThumbnailShown();
+    void onImageShown();
+}

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageShownCallback.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageShownCallback.java
@@ -3,8 +3,8 @@ package com.github.piasy.biv.view;
 import androidx.annotation.UiThread;
 
 @UiThread
-public interface ImageCycleCallback {
+public interface ImageShownCallback {
 
     void onThumbnailShown();
-    void onImageShown();
+    void onMainImageShown();
 }

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageViewFactory.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageViewFactory.java
@@ -60,6 +60,6 @@ public class ImageViewFactory {
     }
 
     public View createThumbnailView(Context context, Uri thumbnail, ImageView.ScaleType scaleType) {
-        return null;
+        return new ImageView(context);
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.github.ben-manes.versions'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion rootProject.ext.androidCompileSdkVersion
@@ -72,8 +73,9 @@ android {
 }
 
 dependencies {
+    implementation "androidx.core:core-ktx:1.1.0"
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "androidx.recyclerview:recyclerview:1.1.0-beta04"
     implementation "com.google.android.material:material:$materialVersion"
 
     implementation('com.tbruyelle.rxpermissions2:rxpermissions:0.9.5') {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,7 @@ android {
 dependencies {
     implementation "androidx.core:core-ktx:1.1.0"
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.1.0-beta04"
+    implementation "androidx.recyclerview:recyclerview:1.1.0-beta05"
     implementation "com.google.android.material:material:$materialVersion"
 
     implementation('com.tbruyelle.rxpermissions2:rxpermissions:0.9.5') {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,8 +23,7 @@
   ~ SOFTWARE.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        package="com.github.piasy.biv.example">
+    package="com.github.piasy.biv.example">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
@@ -52,6 +51,8 @@
         <activity android:name=".CustomSSIVActivity"/>
         <activity android:name=".RecyclerViewActivity"/>
         <activity android:name=".ImageTypesActivity"/>
+        <activity android:name=".FirstAnimActivity" android:theme="@style/TransitionTheme"/>
+        <activity android:name=".SecondAnimActivity" android:theme="@style/TransitionTheme"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/piasy/biv/example/FirstAnimActivity.kt
+++ b/app/src/main/java/com/github/piasy/biv/example/FirstAnimActivity.kt
@@ -1,0 +1,31 @@
+package com.github.piasy.biv.example
+
+import android.os.Bundle
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+
+class FirstAnimActivity : AppCompatActivity() {
+
+    companion object {
+        private const val THUMB_URL = "https://preview.redd.it/nahhvcadsbo21.jpg?width=216&crop=smart&auto=webp&s=c560e5774d7f43e178c1f0faad09315cdb86c203"
+        private const val SOURCE_URL = "https://i.redd.it/nahhvcadsbo21.jpg"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_anim_first)
+
+        val thumb = findViewById<ImageView>(R.id.thumbView)
+        thumb.setOnClickListener {
+
+            SecondAnimActivity.start(this, thumb, THUMB_URL, SOURCE_URL)
+        }
+
+        val glide = Glide.with(this)
+        glide.asBitmap()
+                .load(THUMB_URL)
+                .into(thumb)
+    }
+}

--- a/app/src/main/java/com/github/piasy/biv/example/LongImageActivity.java
+++ b/app/src/main/java/com/github/piasy/biv/example/LongImageActivity.java
@@ -25,14 +25,16 @@
 package com.github.piasy.biv.example;
 
 import android.Manifest;
-import android.app.Dialog;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.github.piasy.biv.BigImageViewer;
@@ -55,7 +57,7 @@ public class LongImageActivity extends AppCompatActivity {
     private Disposable mPermissionRequest;
     private Disposable mQrCodeDecode;
 
-    private Dialog dialog;
+    private AlertDialog dialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -73,36 +75,13 @@ public class LongImageActivity extends AppCompatActivity {
             }
         });
 
-        dialog = new Dialog(this);
-        dialog.setTitle(R.string.long_click_actions);
-        dialog.setContentView(R.layout.dialog_long_image);
-
-        final WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
-        lp.copyFrom(dialog.getWindow().getAttributes());
-        lp.width = WindowManager.LayoutParams.MATCH_PARENT;
-        dialog.getWindow().setAttributes(lp);
-
-        final TextView textScan = dialog.findViewById(R.id.action_scan_qr);
-        final TextView textSave = dialog.findViewById(R.id.action_save_image);
-
-        textScan.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                decodeQrCode();
-            }
-        });
-
-        textSave.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                saveImage();
-            }
-        });
-
         mBigImageView.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
+
+                dialog = showDialog();
                 dialog.show();
+
                 return true;
             }
         });
@@ -140,10 +119,6 @@ public class LongImageActivity extends AppCompatActivity {
 
         disposePermissionRequest();
         disposeQrCodeDecode();
-
-        if (dialog.isShowing()) {
-            dialog.dismiss();
-        }
 
         BigImageViewer.imageLoader().cancelAll();
     }
@@ -193,6 +168,33 @@ public class LongImageActivity extends AppCompatActivity {
                         throwable.printStackTrace();
                     }
                 });
+    }
+
+    private AlertDialog showDialog() {
+
+        final ViewGroup container = findViewById(R.id.container);
+        final AlertDialog.Builder builder = new AlertDialog.Builder(LongImageActivity.this);
+        final View rootView = LayoutInflater.from(LongImageActivity.this).inflate(R.layout.dialog_long_image, container, false);
+        builder.setView(rootView);
+
+        final TextView textScan = rootView.findViewById(R.id.action_scan_qr);
+        final TextView textSave = rootView.findViewById(R.id.action_save_image);
+
+        textScan.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                decodeQrCode();
+            }
+        });
+
+        textSave.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                saveImage();
+            }
+        });
+
+        return builder.create();
     }
 
     private void disposePermissionRequest() {

--- a/app/src/main/java/com/github/piasy/biv/example/MainActivity.java
+++ b/app/src/main/java/com/github/piasy/biv/example/MainActivity.java
@@ -84,5 +84,11 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(new Intent(MainActivity.this, ImageTypesActivity.class));
             }
         });
+        findViewById(R.id.mSharedTransition).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(MainActivity.this, FirstAnimActivity.class));
+            }
+        });
     }
 }

--- a/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
+++ b/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
@@ -1,0 +1,101 @@
+package com.github.piasy.biv.example
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.transition.Transition
+import android.util.Log
+import android.view.MenuItem
+import android.widget.ImageView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityOptionsCompat
+import androidx.core.net.toUri
+import com.github.piasy.biv.BigImageViewer
+import com.github.piasy.biv.loader.glide.GlideImageLoader
+import com.github.piasy.biv.view.BigImageView
+import com.github.piasy.biv.view.ImageCycleCallback
+
+class SecondAnimActivity : AppCompatActivity() {
+
+    companion object {
+
+        private const val THUMB_PARAM = "intent_param_thumbnail"
+        private const val SOURCE_PARAM = "intent_param_source"
+
+        fun start(activity: Activity, imageView: ImageView, thumbUrl: String, sourceUrl: String) {
+
+            val intent = Intent(activity, SecondAnimActivity::class.java)
+            intent.putExtra(THUMB_PARAM, thumbUrl)
+            intent.putExtra(SOURCE_PARAM, sourceUrl)
+
+            val transitionName = activity.resources.getString(R.string.transition_name)
+            val options = ActivityOptionsCompat.makeSceneTransitionAnimation(activity, imageView, transitionName)
+            val bundle = options.toBundle()
+
+            if (Build.VERSION.SDK_INT >= 16) {
+                activity.startActivity(intent, bundle)
+            } else {
+                Log.i("SecondAnimActivity", "Animation not available for this SDK Versions.")
+            }
+        }
+    }
+
+    private val thumbUrl by lazy { intent.getStringExtra(THUMB_PARAM)!! }
+    private val sourceUrl by lazy { intent.getStringExtra(SOURCE_PARAM)!! }
+
+    private val biv by lazy { findViewById<BigImageView>(R.id.sourceView) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        BigImageViewer.initialize(GlideImageLoader.with(applicationContext))
+
+        setContentView(R.layout.activity_anim_second)
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            window.sharedElementEnterTransition.addListener(object : Transition.TransitionListener {
+
+                override fun onTransitionStart(transition: Transition?) {}
+                override fun onTransitionCancel(transition: Transition?) {}
+                override fun onTransitionPause(transition: Transition?) {}
+                override fun onTransitionResume(transition: Transition?) {}
+
+                override fun onTransitionEnd(transition: Transition?) {
+
+                    biv.triggerImageSwap()
+                }
+            })
+        }
+
+        biv.setImageCycleCallback(object : ImageCycleCallback {
+
+            override fun onThumbnailShown() {
+                showToast("onThumbnailShown triggered!")
+            }
+
+            override fun onImageShown() {
+                showToast("onImageShown triggered!")
+            }
+        })
+
+        biv.showImage(thumbUrl.toUri(), sourceUrl.toUri(), true)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+
+        when(item.itemId) {
+            android.R.id.home -> {
+                supportFinishAfterTransition()
+                return true
+            }
+        }
+
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun showToast(text: String) {
+        Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
+++ b/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
@@ -15,7 +15,7 @@ import androidx.core.net.toUri
 import com.github.piasy.biv.BigImageViewer
 import com.github.piasy.biv.loader.glide.GlideImageLoader
 import com.github.piasy.biv.view.BigImageView
-import com.github.piasy.biv.view.ImageCycleCallback
+import com.github.piasy.biv.view.ImageShownCallback
 
 class SecondAnimActivity : AppCompatActivity() {
 
@@ -64,19 +64,19 @@ class SecondAnimActivity : AppCompatActivity() {
 
                 override fun onTransitionEnd(transition: Transition?) {
 
-                    biv.triggerImageSwap()
+                    biv.loadMainImageNow()
                 }
             })
         }
 
-        biv.setImageCycleCallback(object : ImageCycleCallback {
+        biv.setImageShownCallback(object : ImageShownCallback {
 
             override fun onThumbnailShown() {
                 showToast("onThumbnailShown triggered!")
             }
 
-            override fun onImageShown() {
-                showToast("onImageShown triggered!")
+            override fun onMainImageShown() {
+                showToast("onMainImageShown triggered!")
             }
         })
 

--- a/app/src/main/res/layout/activity_anim_first.xml
+++ b/app/src/main/res/layout/activity_anim_first.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FirstAnimActivity">
+
+    <TextView
+        android:id="@+id/firstHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:textAlignment="center"
+        android:textColor="@android:color/black"
+        android:textSize="21sp"
+        android:textStyle="bold"
+        android:text="@string/header_first_activity"
+        />
+
+    <ImageView
+        android:id="@+id/thumbView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:transitionName="@string/transition_name"
+        android:contentDescription="@string/content_desc_thumb" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_anim_second.xml
+++ b/app/src/main/res/layout/activity_anim_second.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SecondAnimActivity">
+
+    <TextView
+        android:id="@+id/secondHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:textAlignment="center"
+        android:textColor="@android:color/black"
+        android:textSize="21sp"
+        android:textStyle="bold"
+        android:text="@string/header_second_activity"
+        />
+
+    <com.github.piasy.biv.view.BigImageView
+        android:id="@+id/sourceView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:transitionName="@string/transition_name"
+        android:contentDescription="@string/content_desc_source"
+        />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_big_image.xml
+++ b/app/src/main/res/layout/activity_big_image.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <com.github.piasy.biv.view.BigImageView
+        android:id="@+id/mBigImage"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/black"
-        >
-    <com.github.piasy.biv.view.BigImageView
-            android:id="@+id/mBigImage"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:optimizeDisplay="true"
-            app:failureImage="@drawable/ic_cloud_off_white"
-            app:failureImageInitScaleType="center"
-            />
+        app:optimizeDisplay="true"
+        app:failureImage="@drawable/ic_cloud_off_white"
+        app:failureImageInitScaleType="center"
+        />
 
     <Button
-            android:id="@+id/mBtnLoad"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="load"
-            />
+        android:id="@+id/mBtnLoad"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/bttn_load"
+        />
 </FrameLayout>

--- a/app/src/main/res/layout/activity_custom_ssiv.xml
+++ b/app/src/main/res/layout/activity_custom_ssiv.xml
@@ -28,8 +28,7 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context="com.github.piasy.biv.example.CustomSSIVActivity"
-        >
+        tools:context="com.github.piasy.biv.example.CustomSSIVActivity">
 
     <com.github.piasy.biv.view.BigImageView
             android:id="@+id/mBigImage"
@@ -41,6 +40,6 @@
             android:id="@+id/mBtnLoad"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="load"
+            android:text="@string/bttn_load"
             />
 </FrameLayout>

--- a/app/src/main/res/layout/activity_image_type.xml
+++ b/app/src/main/res/layout/activity_image_type.xml
@@ -53,7 +53,7 @@
             <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Image Loader:"
+                    android:text="@string/header_image_loader"
                     android:textSize="16sp"
                     />
 
@@ -77,7 +77,7 @@
             <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Image Type:"
+                    android:text="@string/header_image_type"
                     android:textSize="16sp"
                     />
 
@@ -94,7 +94,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="10dp"
-                android:text="load"
+                android:text="@string/bttn_load"
                 />
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,57 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        >
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    >
 
     <Button
-            android:id="@+id/mFresco"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="fresco loader"
-            />
+        android:id="@+id/mFresco"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/main_fresco"
+        />
     <Button
-            android:id="@+id/mGlide"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="glide loader"
-            />
+        android:id="@+id/mGlide"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/main_glide"
+        />
     <Button
-            android:id="@+id/mLongImage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="long image"
-            />
+        android:id="@+id/mLongImage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/main_long"
+        />
     <Button
-            android:id="@+id/mScaleType"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="scale type"
-            />
+        android:id="@+id/mScaleType"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/main_scale"
+        />
     <Button
         android:id="@+id/mImageLoaderCallback"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="image loader callback"
+        android:layout_margin="8dp"
+        android:text="@string/main_callback"
         />
     <Button
         android:id="@+id/mCustomSSIV"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Custom SSIV"
+        android:layout_margin="8dp"
+        android:text="@string/main_custom_ssiv"
         />
     <Button
         android:id="@+id/mRecycler"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Recycler"
+        android:layout_margin="8dp"
+        android:text="@string/main_recycler"
         />
     <Button
         android:id="@+id/mImageTypes"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="image types"
+        android:layout_margin="8dp"
+        android:text="@string/main_types"
+        />
+    <Button
+        android:id="@+id/mSharedTransition"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/main_shared_trans"
         />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_scale_type.xml
+++ b/app/src/main/res/layout/activity_scale_type.xml
@@ -4,8 +4,8 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/black"
-        >
+        android:background="@android:color/black">
+
     <com.github.piasy.biv.view.BigImageView
             android:id="@+id/mBigImage"
             android:layout_width="match_parent"
@@ -38,9 +38,9 @@
             android:id="@+id/mBtnLoad"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:layout_marginTop="15dp"
             android:layout_marginRight="15dp"
-            android:text="load"
+            android:text="@string/bttn_load"
             />
 </FrameLayout>

--- a/app/src/main/res/layout/item_recycler_view.xml
+++ b/app/src/main/res/layout/item_recycler_view.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
   <com.github.piasy.biv.view.BigImageView
       android:id="@+id/itemImage"

--- a/app/src/main/res/values-w820dp/dimens.xml
+++ b/app/src/main/res/values-w820dp/dimens.xml
@@ -1,6 +1,0 @@
-<resources>
-    <!-- Example customization of dimensions originally defined in res/values/dimens.xml
-         (such as screen margins) for screens with more than 820dp of available width. This
-         would include 7" and 10" devices in landscape (~960dp and ~1280dp respectively). -->
-    <dimen name="activity_horizontal_margin">64dp</dimen>
-</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,0 @@
-<resources>
-    <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,13 +1,31 @@
 <resources>
     <string name="app_name">BIV</string>
 
+    <string name="main_fresco">fresco loader</string>
+    <string name="main_glide">glide loader</string>
+    <string name="main_long">long image</string>
+    <string name="main_scale">scale type</string>
+    <string name="main_callback">image loader callback</string>
+    <string name="main_custom_ssiv">Custom SSIV</string>
+    <string name="main_recycler">Recycler</string>
+    <string name="main_types">image types</string>
+    <string name="main_shared_trans">shared elem. transition</string>
+
+    <string name="bttn_load">Load</string>
+
+    <string name="header_image_loader">Image Loader:</string>
+    <string name="header_image_type">Image Type:</string>
+    <string name="header_first_activity">First Activity:</string>
+    <string name="header_second_activity">Second Activity:</string>
+
+    <string name="transition_name">shared_transition_element_view</string>
+    
+    <string name="content_desc_thumb">Thumbnail Image</string>
+    <string name="content_desc_source">Source Image</string>
+
     <string name="long_click_actions">Actions:</string>
     <string name="scan_qr_code">recognize qr code</string>
     <string name="save_image">save to gallery</string>
-    <string-array name="big_image_ops">
-        <item>@string/scan_qr_code</item>
-        <item>@string/save_image</item>
-    </string-array>
 
     <string name="scale_center_crop">centerCrop</string>
     <string name="scale_center_inside">centerInside</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
@@ -6,6 +6,10 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+    <style name="TransitionTheme" parent="AppTheme">
+        <item name="android:windowContentTransitions" tools:targetApi="lollipop">true</item>
     </style>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50"
+
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
@@ -87,6 +89,6 @@ ext {
 
     frescoVersion = '2.0.0'
     glideVersion = '4.10.0'
-    okhttpVersion = '4.2.1'
+    okhttpVersion = '4.2.2'
     ssivVersion = '3.10.0'
 }


### PR DESCRIPTION
Hi, this is the work I did to make BigImageViewer better support shared transition animations,
this is all working and tested, but this is only a starting point.

The problem, as described in #98, is that while the animation is running between two activities, the View switches the thumbnailView and the SSIV, causing stutters, or black frames, or an animation that does not run at all.

My suggestion is to have an additional parameter to only show the thumbnail for the transition and delay the main image loading, so we can trigger it later using listeners.

I've made those modifications, and a test environment, using two activities and it does work, while not breaking the others activities in the sample app.

I've added another listener for testing purposes, tell me if you want to keep it or not.

While working with the sample app, I reduced the number of warnings, moving harcoded strings in resources and other stuff, hope you don't mind. Bumped okhttp to the next minor too.

What do you think? would you do it in a different way? 

Good night for now.