### PR TITLE
corrected exit tranisition animation with zoom

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -114,6 +114,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
     private ProgressIndicator mProgressIndicator;
     private DisplayOptimizeListener mDisplayOptimizeListener;
     private int mInitScaleType;
+    private boolean mThumbnailAdjustViewBounds;
     private ImageView.ScaleType mThumbnailScaleType;
     private ImageView.ScaleType mFailureImageScaleType;
     private boolean mOptimizeDisplay;
@@ -166,6 +167,8 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
 
         mOptimizeDisplay = array.getBoolean(R.styleable.BigImageView_optimizeDisplay, true);
         mTapToRetry = array.getBoolean(R.styleable.BigImageView_tapToRetry, true);
+
+        mThumbnailAdjustViewBounds = array.getBoolean(R.styleable.BigImageView_thumbnailAdjustViewBounds, false);
 
         array.recycle();
 
@@ -413,7 +416,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
         // why show thumbnail in onStart? because we may not need download it from internet
         if (mThumbnail != Uri.EMPTY) {
             mThumbnailView = mViewFactory.createThumbnailView(getContext(), mThumbnailScaleType,
-                    true);
+                    mThumbnailAdjustViewBounds, true);
             mViewFactory.loadThumbnailContent(mThumbnailView, mThumbnail);
             if (mThumbnailView != null) {
                 addView(mThumbnailView, ViewGroup.LayoutParams.MATCH_PARENT,
@@ -537,7 +540,7 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
             }
 
             mThumbnailView = mViewFactory.createThumbnailView(getContext(), mThumbnailScaleType,
-                    false);
+                    mThumbnailAdjustViewBounds,false);
             if (mThumbnailView != null) {
                 addView(mThumbnailView, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
 
@@ -545,6 +548,9 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
                 mThumbnailView.setOnLongClickListener(mOnLongClickListener);
 
                 if (mThumbnailView instanceof ImageView) {
+                    ((ImageView) mThumbnailView).setAdjustViewBounds(true);
+                    ((ImageView) mThumbnailView).setScaleType(ImageView.ScaleType.FIT_START);
+
                     mViewFactory.loadThumbnailContent(mThumbnailView, image);
 
                     if (mImageShownCallback != null) {

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -548,8 +548,6 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
                 mThumbnailView.setOnLongClickListener(mOnLongClickListener);
 
                 if (mThumbnailView instanceof ImageView) {
-                    ((ImageView) mThumbnailView).setAdjustViewBounds(true);
-                    ((ImageView) mThumbnailView).setScaleType(ImageView.ScaleType.FIT_START);
 
                     mViewFactory.loadThumbnailContent(mThumbnailView, image);
 

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -55,6 +55,8 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_OUT_QUAD;
+
 /**
  * Created by Piasy{github.com/Piasy} on 06/11/2016.
  * <p>
@@ -388,6 +390,81 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
 
     public SubsamplingScaleImageView getSSIV() {
         return mSSIV;
+    }
+
+    public boolean isZoomEnabled() {
+        if (mSSIV != null) {
+            return mSSIV.isZoomEnabled();
+        } else {
+            return false;
+        }
+    }
+
+    public float getCurrentScale() {
+        if(mSSIV != null) {
+            return mSSIV.getScale();
+        } else {
+            return 0;
+        }
+    }
+
+    public void animateMinScale(final int duration) {
+        animateMinScale(duration, null);
+    }
+
+    public void animateMinScale(final int duration,
+                                final SubsamplingScaleImageView.OnAnimationEventListener listener) {
+
+        if (mSSIV != null && mSSIV.isReady()) {
+            animateToScale(mSSIV.getMinScale(), duration, listener);
+        }
+    }
+
+    public void animateMaxScale(final int duration) {
+        animateMaxScale(duration, null);
+    }
+
+    public void animateMaxScale(final int duration,
+                                final SubsamplingScaleImageView.OnAnimationEventListener listener) {
+
+        if (mSSIV != null && mSSIV.isReady()) {
+            animateToScale(mSSIV.getMaxScale(), duration, listener);
+        }
+    }
+
+    public void animateToScale(final float scale, final int duration) {
+        animateToScale(scale, duration, null);
+    }
+
+    public void animateToScale(final float scale, final int duration,
+                               final SubsamplingScaleImageView.OnAnimationEventListener listener) {
+
+        if (mSSIV != null && mSSIV.isReady()) {
+            final SubsamplingScaleImageView.AnimationBuilder builder = mSSIV.animateScale(scale);
+            if (builder != null) {
+                builder.withDuration(duration)
+                        .withEasing(EASE_OUT_QUAD)
+                        .withInterruptible(false)
+                        .withOnAnimationEventListener(listener)
+                        .start();
+            }
+        }
+    }
+
+    public float getMinScale() {
+        if (mSSIV != null) {
+            return mSSIV.getMinScale();
+        } else {
+            return 0;
+        }
+    }
+
+    public float getMaxScale() {
+        if (mSSIV != null) {
+            return mSSIV.getMaxScale();
+        } else {
+            return 0;
+        }
     }
 
     @Override

--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageViewFactory.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/ImageViewFactory.java
@@ -80,8 +80,9 @@ public class ImageViewFactory {
     }
 
     public View createThumbnailView(final Context context, final ImageView.ScaleType scaleType,
-            final boolean willLoadFromNetwork) {
+            final boolean adjustViewBounds, final boolean willLoadFromNetwork) {
         final ImageView thumbnailView = new ImageView(context);
+        thumbnailView.setAdjustViewBounds(adjustViewBounds);
         if (scaleType != null) {
             thumbnailView.setScaleType(scaleType);
         }

--- a/BigImageViewer/src/main/res/values/attrs.xml
+++ b/BigImageViewer/src/main/res/values/attrs.xml
@@ -58,5 +58,6 @@
             <enum name="fitStart" value="5" />
             <enum name="fitXY" value="6" />
         </attr>
+        <attr name="thumbnailAdjustViewBounds" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/FrescoImageViewFactory/src/main/java/com/github/piasy/biv/view/FrescoImageViewFactory.java
+++ b/FrescoImageViewFactory/src/main/java/com/github/piasy/biv/view/FrescoImageViewFactory.java
@@ -59,17 +59,18 @@ public class FrescoImageViewFactory extends ImageViewFactory {
     }
 
     @Override
-    public final View createThumbnailView(final Context context,
-            final ImageView.ScaleType scaleType, final boolean willLoadFromNetwork) {
+    public final View createThumbnailView(final Context context, final ImageView.ScaleType scaleType,
+                                          final boolean adjustViewBounds, final boolean willLoadFromNetwork) {
         if (willLoadFromNetwork) {
             final SimpleDraweeView thumbnailView = new SimpleDraweeView(context);
             if (scaleType != null) {
                 thumbnailView.getHierarchy().setActualImageScaleType(scaleType(scaleType));
+                thumbnailView.setAdjustViewBounds(adjustViewBounds);
             }
 
             return thumbnailView;
         } else {
-            return super.createThumbnailView(context, scaleType, false);
+            return super.createThumbnailView(context, scaleType, adjustViewBounds, false);
         }
     }
 

--- a/app/src/main/java/com/github/piasy/biv/example/FirstAnimFrescoActivity.kt
+++ b/app/src/main/java/com/github/piasy/biv/example/FirstAnimFrescoActivity.kt
@@ -27,7 +27,6 @@ package com.github.piasy.biv.example
 import android.os.Bundle
 import android.view.View
 import android.widget.CheckBox
-import android.widget.RadioButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.app.SharedElementCallback
@@ -64,16 +63,11 @@ class FirstAnimFrescoActivity : AppCompatActivity() {
             }
         })
 
-        val useGlide = findViewById<RadioButton>(R.id.use_glide)
-        val useFresco = findViewById<RadioButton>(R.id.use_fresco)
         val useViewFactory = findViewById<CheckBox>(R.id.check_use_view_factory)
 
         thumb.setOnClickListener {
-            SecondAnimActivity.start(
-                this, thumb,
-                THUMB_URL, SOURCE_URL,
-                useGlide.isChecked, useFresco.isChecked, useViewFactory.isChecked
-            )
+            SecondAnimActivity.start(this, thumb, THUMB_URL, SOURCE_URL,
+                false, true, useViewFactory.isChecked)
         }
 
         thumb.setLegacyVisibilityHandlingEnabled(true)

--- a/app/src/main/java/com/github/piasy/biv/example/FirstAnimGlideActivity.kt
+++ b/app/src/main/java/com/github/piasy/biv/example/FirstAnimGlideActivity.kt
@@ -3,7 +3,6 @@ package com.github.piasy.biv.example
 import android.os.Bundle
 import android.widget.CheckBox
 import android.widget.ImageView
-import android.widget.RadioButton
 import androidx.appcompat.app.AppCompatActivity
 import com.bumptech.glide.Glide
 
@@ -22,16 +21,11 @@ class FirstAnimGlideActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_anim_first_glide)
 
-        val useGlide = findViewById<RadioButton>(R.id.use_glide)
-        val useFresco = findViewById<RadioButton>(R.id.use_fresco)
         val useViewFactory = findViewById<CheckBox>(R.id.check_use_view_factory)
 
         thumb.setOnClickListener {
-            SecondAnimActivity.start(
-                this, thumb,
-                THUMB_URL, SOURCE_URL,
-                useGlide.isChecked, useFresco.isChecked, useViewFactory.isChecked
-            )
+            SecondAnimActivity.start(this, thumb, THUMB_URL, SOURCE_URL,
+                true, false, useViewFactory.isChecked)
         }
 
         val glide = Glide.with(this)

--- a/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
+++ b/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
@@ -107,22 +107,24 @@ class SecondAnimActivity : AppCompatActivity() {
 
         if (Build.VERSION.SDK_INT >= 21) {
 
-            setEnterSharedElementCallback(object : SharedElementCallback() {
+            if (useFresco) {
+                setEnterSharedElementCallback(object : SharedElementCallback() {
 
-                override fun onSharedElementEnd(
-                        names: MutableList<String>?,
-                        elements: MutableList<View>?,
-                        snapshots: MutableList<View>?
-                ) {
-                    super.onSharedElementEnd(names, elements, snapshots)
+                    override fun onSharedElementEnd(
+                            names: MutableList<String>?,
+                            elements: MutableList<View>?,
+                            snapshots: MutableList<View>?
+                    ) {
+                        super.onSharedElementEnd(names, elements, snapshots)
 
-                    elements?.forEach {
-                        if (it is SimpleDraweeView) {
-                            it.post { it.setVisibility(View.VISIBLE) }
+                        elements?.forEach {
+                            if (it is SimpleDraweeView) {
+                                it.post { it.setVisibility(View.VISIBLE) }
+                            }
                         }
                     }
-                }
-            })
+                })
+            }
 
             window.sharedElementEnterTransition.addListener(object : Transition.TransitionListener {
 

--- a/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
+++ b/app/src/main/java/com/github/piasy/biv/example/SecondAnimActivity.kt
@@ -53,7 +53,7 @@ class SecondAnimActivity : AppCompatActivity() {
 
             if (Build.VERSION.SDK_INT >= 16) {
 
-                if (Build.VERSION.SDK_INT >= 21) {
+                if (useFresco && Build.VERSION.SDK_INT >= 21) {
                     activity.setExitSharedElementCallback(object : SharedElementCallback() {
 
                         override fun onSharedElementEnd(
@@ -89,7 +89,9 @@ class SecondAnimActivity : AppCompatActivity() {
     private val biv by lazy { findViewById<BigImageView>(R.id.sourceView) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        Fresco.initialize(this)
+        if (useFresco) {
+            Fresco.initialize(this)
+        }
 
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/res/layout/activity_anim_first_fresco.xml
+++ b/app/src/main/res/layout/activity_anim_first_fresco.xml
@@ -42,30 +42,6 @@
         android:text="@string/header_first_activity"
         />
 
-    <RadioGroup
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <RadioButton
-            android:id="@+id/use_glide"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:text="@string/radio_use_glide"
-            android:checked="true"
-            />
-
-        <RadioButton
-            android:id="@+id/use_fresco"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:text="@string/radio_use_fresco"
-            />
-
-    </RadioGroup>
-
     <CheckBox
         android:id="@+id/check_use_view_factory"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_anim_first_glide.xml
+++ b/app/src/main/res/layout/activity_anim_first_glide.xml
@@ -18,30 +18,6 @@
         android:text="@string/header_first_activity"
         />
 
-    <RadioGroup
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <RadioButton
-            android:id="@+id/use_glide"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:text="@string/radio_use_glide"
-            android:checked="true"
-            />
-
-        <RadioButton
-            android:id="@+id/use_fresco"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:text="@string/radio_use_fresco"
-            />
-
-    </RadioGroup>
-
     <CheckBox
         android:id="@+id/check_use_view_factory"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_anim_second.xml
+++ b/app/src/main/res/layout/activity_anim_second.xml
@@ -19,6 +19,40 @@
         android:text="@string/header_second_activity"
         />
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/min_scale"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:layout_weight="1"
+            android:text="@string/bttn_min_scale"
+            />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/max_scale"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:layout_weight="1"
+            android:text="@string/bttn_max_scale"
+            />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/half_scale"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:layout_weight="1"
+            android:text="@string/bttn_half_scale"
+            />
+
+    </LinearLayout>
+
     <com.github.piasy.biv.view.BigImageView
         android:id="@+id/sourceView"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_anim_second.xml
+++ b/app/src/main/res/layout/activity_anim_second.xml
@@ -27,6 +27,7 @@
         android:transitionName="@string/transition_name"
         android:contentDescription="@string/content_desc_source"
         app:thumbnailScaleType="fitStart"
+        app:thumbnailAdjustViewBounds="true"
         />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_anim_second.xml
+++ b/app/src/main/res/layout/activity_anim_second.xml
@@ -26,6 +26,7 @@
         android:layout_marginTop="16dp"
         android:transitionName="@string/transition_name"
         android:contentDescription="@string/content_desc_source"
+        app:thumbnailScaleType="fitStart"
         />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,10 @@
     <string name="scan_qr_code">recognize qr code</string>
     <string name="save_image">save to gallery</string>
 
+    <string name="bttn_min_scale">Min Scale</string>
+    <string name="bttn_max_scale">Max Scale</string>
+    <string name="bttn_half_scale">Half Scale</string>
+
     <string name="scale_center_crop">centerCrop</string>
     <string name="scale_center_inside">centerInside</string>
     <string name="scale_custom">custom</string>


### PR DESCRIPTION
Hi, 
I'm committing what we discussed in #176,
I've fixed the sample app, divided in two activities, and fixed the exit out animation while zoomed in the second activity.

We can delay the exit animation using finishAfterTransition() and un-zooming with some controls that I added to BIV.

Check it out, and let me know if it's good to commit. I want to try this in my app.

PS: I see some distorsion on Fresco, I see it has it's own animations method, we should try that,
I think, this lib should not fix the weirdness of Fresco, we integrated well with transition animation, that should be the end of it.