### PR TITLE
BigImageView: add a chance to get a main view

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/view/BigImageView.java
@@ -432,6 +432,10 @@ public class BigImageView extends FrameLayout implements ImageLoader.Callback {
     public SubsamplingScaleImageView getSSIV() {
         return mSSIV;
     }
+    
+    public View getMainView() {
+        return mMainView;
+    }
 
     @Override
     public void onCacheHit(final int imageType, final File image) {


### PR DESCRIPTION
This can be potentially used to apply transitions, custom touch handlers to view even if it's not an SSIV or, let's say, GifImageView or standard Android's ImageView.