### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pan and zoom               |  gif support
 allprojects {
     repositories {
         maven {
-            url  "http://dl.bintray.com/piasy/maven"
+            url  "https://dl.bintray.com/piasy/maven"
         }
     }
 }


### PR DESCRIPTION
Fixes gradle warning
```
Using insecure protocols with repositories has been deprecated. This is scheduled to be removed in Gradle 7.0. Switch Maven repository 'maven(http://dl.bintray.com/piasy/maven)' to a secure protocol (like HTTPS) or allow insecure protocols. See https://docs.gradle.org/6.5/dsl/org.gradle.api.artifacts.repositories.UrlArtifactRepository.html#org.gradle.api.artifacts.repositories.UrlArtifactRepository:allowInsecureProtocol for more details.
```