### PR TITLE
Fix the issue of determining animated WebP

### DIFF
--- a/BigImageViewer/src/main/java/com/github/piasy/biv/metadata/ImageInfoExtractor.java
+++ b/BigImageViewer/src/main/java/com/github/piasy/biv/metadata/ImageInfoExtractor.java
@@ -45,8 +45,9 @@ public final class ImageInfoExtractor {
 
     /**
      * For GIF, we only need 3 bytes, 'GIF',
-     * For WebP, we need 12 bytes, 'RIFF' + size + 'WEBP',
-     * to determine still/animated WebP, we need 5 extra bytes, 4 bytes chunk header to check
+     *
+     * For WebP format, we need 21 bytes, `RIFF` + size + `WEBP` + ChuckHeader(`VP8X`),
+     * to determine still/animated WebP, we need 9 extra bytes, 8 bytes chunk header to check
      * for extended WebP format, 1 byte to check for animated bit.
      *
      * reference: https://developers.google.com/speed/webp/docs/riff_container
@@ -56,13 +57,13 @@ public final class ImageInfoExtractor {
         try {
             FileInputStream inputStream = new FileInputStream(file);
 
-            byte[] header = new byte[20];
+            byte[] header = new byte[21];
             int read = inputStream.read(header);
             if (read >= 3 && isGifHeader(header)) {
                 type = TYPE_GIF;
             } else if (read >= 12 && isWebpHeader(header)) {
                 if (read >= 17 && isExtendedWebp(header)
-                    && (header[16] & ANIMATED_WEBP_MASK) != 0) {
+                    && (header[20] & ANIMATED_WEBP_MASK) != 0) {
                     type = TYPE_ANIMATED_WEBP;
                 } else {
                     type = TYPE_STILL_WEBP;


### PR DESCRIPTION
The condition of determining animated WebP in BigImageViewer might be wrong.

Based on what google said in [WebP Container Specification#Extended File Format](https://developers.google.com/speed/webp/docs/riff_container#extended_file_format), animation bit is in byte 21 instead of byte 17.

You may mistaken `ChunkHeader(VP8X)` as a 4-bytes data while it's 8 bytes instead.

